### PR TITLE
SecureCommand: removed unnecessary data_length fields

### DIFF
--- a/dronecan/remoteid/64.SecureCommand.uavcan
+++ b/dronecan/remoteid/64.SecureCommand.uavcan
@@ -11,7 +11,6 @@ uint32 SECURE_COMMAND_GET_REMOTEID_CONFIG = 5
 uint32 SECURE_COMMAND_SET_REMOTEID_CONFIG = 6
 uint32 operation
 
-uint8 data_length
 uint8 sig_length
 uint8[<=220] data
 
@@ -27,5 +26,4 @@ uint8 RESULT_UNSUPPORTED = 3
 uint8 RESULT_FAILED = 4
 uint8 result
 
-uint8 data_length
 uint8[<=220] data


### PR DESCRIPTION
use array length