### PR TITLE
Added config get and set message

### DIFF
--- a/dronecan/protocol/100.NodeConfig.uavcan
+++ b/dronecan/protocol/100.NodeConfig.uavcan
@@ -1,0 +1,60 @@
+#
+# Node configuration. This message can be sent to a node to set
+# configuration items that are common to all nodes. It is also used as a response
+# to a request for these currently-set values. It provides a simple
+# implementation to get or set these items.
+#
+# To set this data, send a message type `dronecan.protocol.100.NodeConfig`, with the payload below.
+#
+# To get this data, send a message of type `dronecan.protocol.101.GetNodeConfig`, with no payload. Response to a get request will be type 100.
+# 
+# Payload size: 5 bytes. Response payload size, if a set request: 1 byte.
+#
+
+uint8 GET_RESPONSE = 0
+uint8 SET = 1
+
+#
+# Use `GET_RESPONSE` if responding to a request. Use `SET` if directing a change
+# of config.
+#
+uint8 get_or_set 
+
+#
+# Node id, as defined in the Specification, section 5. Must be between 1 and 127.
+#
+uint8 node_id  
+
+uint8 FD_MODE = 1
+uint8 LEGACY_MODE = 0
+
+#
+# Determines if the node operates in FD mode, ie capable of 64-byte frames,
+# or legacy mode, capable of 8-byte frames. Set to 1 for FD mode, or 0 for
+# legacy mode.
+#
+uint8 fd_mode
+
+#
+# CAN bitrate to use, in kilobits per seconds. The node is expected to immediately
+# switch to this, including in its acknowledgement to this message. The maximum value
+# is 8000, due to hardware limitations of CAN FD.
+#
+uint16 can_bitrate
+
+
+---
+
+
+#
+# Response, if a set request.
+#
+
+uint8 SUCCESS = 0
+uint8 ERROR = 1
+
+#
+# A result of 1 indicates an error setting the config, while a response of 0 inciates
+# the config was set successfully.
+#
+uint8 result

--- a/dronecan/protocol/100.NodeConfig.uavcan
+++ b/dronecan/protocol/100.NodeConfig.uavcan
@@ -4,12 +4,16 @@
 # to a request for these currently-set values. It provides a simple
 # implementation to get or set these items.
 #
-# To set this data, send a message type `dronecan.protocol.100.NodeConfig`, with the payload below.
+# To set this data, send a message type `dronecan.protocol.100.NodeConfig`, with the payload
+# below.
 #
-# To get this data, send a message of type `dronecan.protocol.101.GetNodeConfig`, with no payload. Response to a get request will be type 100.
+# To get this data, send a message of type `dronecan.protocol.101.GetNodeConfig`, with no 
+# payload. Response to a set request will be of type `dronecan.protocol.102.Ack`, indicating
+# success or failure.
 # 
-# Payload size: 5 bytes. Response payload size, if a set request: 1 byte.
+# Payload size: 5 bytes.
 #
+
 
 uint8 GET_RESPONSE = 0
 uint8 SET = 1
@@ -41,20 +45,3 @@ uint8 fd_mode
 # is 8000, due to hardware limitations of CAN FD.
 #
 uint16 can_bitrate
-
-
----
-
-
-#
-# Response, if a set request.
-#
-
-uint8 SUCCESS = 0
-uint8 ERROR = 1
-
-#
-# A result of 1 indicates an error setting the config, while a response of 0 inciates
-# the config was set successfully.
-#
-uint8 result

--- a/dronecan/protocol/101.GetNodeConfig - Copy.uavcan
+++ b/dronecan/protocol/101.GetNodeConfig - Copy.uavcan
@@ -1,5 +1,0 @@
-#
-# Get node configuration, using data type 101. No payload. The expected response format is 
-# `dronecan.protocol.100.NodeConfig`, with `get_or_set` = 0. See that message type
-# for details.
-#

--- a/dronecan/protocol/101.GetNodeConfig - Copy.uavcan
+++ b/dronecan/protocol/101.GetNodeConfig - Copy.uavcan
@@ -3,5 +3,3 @@
 # `dronecan.protocol.100.NodeConfig`, with `get_or_set` = 0. See that message type
 # for details.
 #
-# Payload size: 0 bytes.
-#

--- a/dronecan/protocol/101.GetNodeConfig.uavcan
+++ b/dronecan/protocol/101.GetNodeConfig.uavcan
@@ -1,0 +1,5 @@
+#
+# Get node configuration, using data type 101. No payload. The expected response format is 
+# `dronecan.protocol.100.NodeConfig`, with `get_or_set` = 0. See that message type
+# for details.
+#

--- a/dronecan/protocol/102.Ack.uavcan
+++ b/dronecan/protocol/102.Ack.uavcan
@@ -1,0 +1,18 @@
+#
+# Acknowledgement to a message with success status, for example to set configuration
+# or parameter.
+#
+# Payload size: 1 byte.
+
+
+#
+# Response, if a set request.
+#
+uint8 SUCCESS = 0
+uint8 ERROR = 1
+
+#
+# A result of 1 indicates an error setting the config, while a response of 0 inciates
+# the config was set successfully.
+#
+uint8 result


### PR DESCRIPTION
This provides an API for setting configuration items that are common to all nodes, and getting their current configuration state from a node. It is a simple, fixed-size format that is easier to implement and debug than `GetSet`. This proposal uses byte-aligned, constant-size fields, and groups together important and universal settings.

Reasons why I think this will be easier to use:

  - `GetSet` has padding bits
  - `GetSet` uses the variable-length `name` field. Strings are a bit awkward to work with here, and aren't required.
  - `GetSet`'s `Value` and `NumericalValue` fields are variable-length; especially for handling string format.
  - It is unclear from its spec how `GetSet`'s set vs get, and expected acknowledgement format work.

Overall, managing `GetSet`'s alignment has nested levels of bit-level, variable-length alignment, which is tricky to implement and debug, given the simple nature of its task. This applies to both serializing and deserializing.

I am open to ideas on data type IDs, fields to add, etc. A notable downside of this proposal is that the format is not very efficient due to byte-level packing, including of fields that have 2 bits. Given this message is expected to be sent infrequently, and is still compact (less than a full legacy frame), I think this is a worthwhile tradeoff. 