### PR TITLE
Add Can Stats and DroneCAN Stats messages

### DIFF
--- a/dronecan/protocol/342.Stats.uavcan
+++ b/dronecan/protocol/342.Stats.uavcan
@@ -1,0 +1,17 @@
+
+#
+# monitor the status of the DroneCAN Protocol decoder on the node
+#
+
+uint32 tx_frames                    # Number of transmitted frames
+uint16 tx_errors                    # Number of errors during transmission
+uint32 rx_frames                    # Number of received frames
+uint16 rx_error_oom                 # Number of out-of-memory errors
+uint16 rx_error_internal            # Number of internal errors
+uint16 rx_error_missed_start        # Number of missed start bits
+uint16 rx_error_wrong_toggle        # Number of wrong toggle bits
+uint16 rx_error_short_frame         # Number of frames that were too short
+uint16 rx_error_bad_crc             # Number of frames with bad CRC
+uint16 rx_ignored_wrong_address     # Number of frames with wrong address
+uint16 rx_ignored_not_wanted        # Number of frames that were not wanted
+uint16 rx_ignored_unexpected_tid    # Number of frames with unexpected TID

--- a/dronecan/protocol/343.CanStats.uavcan
+++ b/dronecan/protocol/343.CanStats.uavcan
@@ -1,0 +1,15 @@
+#
+# Monitor the stats of physical layer on the node
+#
+
+uint8 interface         # interface number
+uint32 tx_requests      # number of tx requests
+uint16 tx_rejected      # number of tx requests rejected
+uint16 tx_overflow      # number of tx requests overflow
+uint16 tx_success       # number of tx requests success
+uint16 tx_timedout      # number of tx requests timedout
+uint16 tx_abort         # number of tx requests aborted
+uint32 rx_received      # number of rx received
+uint16 rx_overflow      # number of rx overflow
+uint16 rx_errors        # number of rx errors
+uint16 busoff_errors    # number of busoff errors


### PR DESCRIPTION
Stats messages will allow us to add this panel to DroneCAN GUI Tool, and look at what sorts of errors are happening at Protocol layer or Physical layer.

![image](https://github.com/dronecan/DSDL/assets/5697288/e3d52e5e-b1b9-40da-a08f-10b348fb7ac3)

