### PR TITLE
add OpenDroneID Auth message to Remote ID DroneCAN message types

### DIFF
--- a/dronecan/remoteid/20036.Auth.uavcan
+++ b/dronecan/remoteid/20036.Auth.uavcan
@@ -1,0 +1,24 @@
+#
+# DroneCAN version of MAVLink OPEN_DRONE_ID_AUTH
+# see MAVLink XML for detailed description
+#
+uint8[<=20] id_or_mac
+
+uint8 ODID_AUTH_TYPE_NONE = 0 # No authentication type is specified.
+uint8 ODID_AUTH_TYPE_UAS_ID_SIGNATURE = 1 # Signature for the UAS (Unmanned Aircraft System) ID.
+uint8 ODID_AUTH_TYPE_OPERATOR_ID_SIGNATURE = 2 # Signature for the Operator ID.
+uint8 ODID_AUTH_TYPE_MESSAGE_SET_SIGNATURE = 3 # Signature for the entire message set.
+uint8 ODID_AUTH_TYPE_NETWORK_REMOTE_ID = 4 # Authentication is provided by Network Remote ID.
+uint8 ODID_AUTH_TYPE_SPECIFIC_AUTHENTICATION = 5 # The exact authentication type is indicated by the first byte of authentication_data and these type values are managed by ICAO.
+
+uint8 authentication_type = 0 # ODID_AUTH_TYPE
+
+uint8 data_page # data_page
+
+uint8 last_page_index # This field is only present for page 0. Allowed range is 0 - 15. See the description of struct ODID_Auth_data at https://github.com/opendroneid/opendroneid-core-c/blob/master/libopendroneid/opendroneid.h.
+
+uint8 length  # [bytes] This field is only present for page 0. Total bytes of authentication_data from all data pages. See the description of struct ODID_Auth_data at https://github.com/opendroneid/opendroneid-core-c/blob/master/libopendroneid/opendroneid.h.
+
+uint32 timestamp # [seconds] This field is only present for page 0. 32 bit Unix Timestamp in seconds since 00:00:00 01/01/2019.
+
+uint8[<=23] # Opaque authentication data. For page 0, the size is only 17 bytes. For other pages, the size is 23 bytes. Shall be filled with nulls in the unused portion of the field.


### PR DESCRIPTION
In the Remote ID message definitions in DroneCAN, there was no definition for Remote ID authentication messages: https://mavlink.io/en/messages/common.html#OPEN_DRONE_ID_AUTHENTICATION

This PR add this definition.