### PR TITLE
Add RPM message: 1045.RPM.uavcan

### DIFF
--- a/dronecan/sensors/rpm/1045.RPM.uavcan
+++ b/dronecan/sensors/rpm/1045.RPM.uavcan
@@ -1,0 +1,11 @@
+#
+# RPM reading in revolutions per minute
+#
+
+uint8 sensor_id
+
+uint16 FLAGS_UNHEALTHY = 1 # Sensor is not healthy
+
+uint16 flags
+
+float32 rpm


### PR DESCRIPTION
Adds a RPM message for things like heli headspeed.

We do have RPM in a couple of other places:
https://github.com/dronecan/DSDL/blob/eb370f198f17e561706d6eaddb02cb06d9e91cf6/com/hobbywing/esc/20050.StatusMsg1.uavcan#L3

https://github.com/dronecan/DSDL/blob/eb370f198f17e561706d6eaddb02cb06d9e91cf6/uavcan/equipment/esc/1031.RPMCommand.uavcan#L8

https://github.com/dronecan/DSDL/blob/eb370f198f17e561706d6eaddb02cb06d9e91cf6/uavcan/equipment/esc/1034.Status.uavcan#L12

https://github.com/dronecan/DSDL/blob/eb370f198f17e561706d6eaddb02cb06d9e91cf6/uavcan/equipment/ice/reciprocating/1120.Status.uavcan#L110

This does use float 32, which is more bits than any of the other rpms but it is a dedicated message, and it still fits in a single frame.

