### PR TITLE
esc: clarify RPM/command direction meaning

### DIFF
--- a/uavcan/equipment/esc/1030.RawCommand.uavcan
+++ b/uavcan/equipment/esc/1030.RawCommand.uavcan
@@ -1,7 +1,9 @@
 #
-# Raw ESC command normalized into [-8192, 8191]; negative values indicate reverse rotation.
-# The ESC should normalize the setpoint into its effective input range.
-# Non-zero setpoint value below minimum should be interpreted as min valid setpoint for the given motor.
+# Raw ESC command normalized into [-8192, 8191]. The ESC should normalize the setpoint into its effective input range.
+# Non-zero setpoint value below minimum should be interpreted as min valid setpoint for the given motor. Positive
+# values indicate forward rotation, negative values indicate reverse rotation, and zero indicates no rotation. For example,
+# a typical quadcopter always commands non-negative values for all four motors, independent of ESC configuration,
+# motor wiring, or propeller direction. ESCs which do not allow reverse rotation shall clamp negative commands to zero.
 #
 
 int14[<=20] cmd

--- a/uavcan/equipment/esc/1031.RPMCommand.uavcan
+++ b/uavcan/equipment/esc/1031.RPMCommand.uavcan
@@ -2,7 +2,9 @@
 # Simple RPM setpoint.
 # The ESC should automatically clamp the setpoint according to the minimum and maximum supported RPM;
 # for example, given a ESC that operates in the range 100 to 10000 RPM, a setpoint of 1 RPM will be clamped to 100 RPM.
-# Negative values indicate reverse rotation.
+# Positive values indicate forward rotation, negative values indicate reverse rotation, and zero indicates no rotation.
+# For example, a typical quadcopter always commands non-negative values for all four motors, independent of ESC configuration,
+# motor wiring, or propeller direction. ESCs which do not allow reverse rotation shall clamp negative RPMs to zero.
 #
 
 int18[<=20] rpm

--- a/uavcan/equipment/esc/1034.Status.uavcan
+++ b/uavcan/equipment/esc/1034.Status.uavcan
@@ -9,7 +9,10 @@ float16 voltage             # Volt
 float16 current             # Ampere. Can be negative in case of a regenerative braking.
 float16 temperature         # Kelvin
 
-int18 rpm                   # Negative value indicates reverse rotation
+int18 rpm                   # Current value, with the same sign convention as RPMCommand. For example, a typical
+                            # quadcopter reports non-negative values for all four motors, independent of ESC
+                            # configuration, motor wiring, or propeller direction. ESCs are expected to report
+                            # negative values if currently spinning in reverse.
 
 uint7 power_rating_pct      # Instant demand factor in percent (percent of maximum power); range 0% to 127%.
 


### PR DESCRIPTION
Reverse should only be used for reverse thrust, not simply a motor that happens to be spinning counter-clockwise.

Some ESC vendors get the RPM feedback backwards when configured in reverse direction, so flight stacks need to be aware; not sure how wide-spread the problem is. I have confirmed that latest AM32 using DroneCAN behaves correctly here: reversing the motor direction in its configuration does not reverse the RPM sign.

I had an additional comment about how an ESC which is running in reverse in response to a supported negative bi-directional command must report a negative RPM but AM32 does not do this. I am not sure where the limitation is but IMO this is a bug, and probably a more wide-spread one.

I further wonder how we should define the motor angle in the extended status. I presume it should be that increasing angles are clockwise? So it would swap if you reversed direction in the ESC, and always match the physical angle. But I am not sure what's best here and don't own any ESCs with angle sensors. We do need to add a note that the percentages are absolute.