### PR TITLE
Satellite Info (1064.Sats)

### DIFF
--- a/uavcan/equipment/gnss/1064.Sats.uavcan
+++ b/uavcan/equipment/gnss/1064.Sats.uavcan
@@ -1,0 +1,27 @@
+#
+# GNSS satellite information.
+# Individual satellite tracking and signal quality data.
+#
+
+#
+# Global network-synchronized time, if available, otherwise zero.
+#
+uavcan.Timestamp timestamp
+
+#
+# Satellite identification
+#
+uint8 svid                         # Space vehicle ID [1..255]
+uint8 prn                          # Satellite PRN code assignment
+
+#
+# Satellite usage and tracking status
+#
+bool used                          # Satellite used for navigation (0: not used, 1: used)
+
+#
+# Satellite geometry and signal quality
+#
+uint8 elevation                    # Elevation angle (0: right on top of receiver, 90: on horizon)
+uint8 azimuth                      # Direction of satellite (0: 0 deg, 255: 360 deg)
+uint8 snr                          # Signal to noise ratio C/N0, range 0..99, zero when not tracking


### PR DESCRIPTION
It would be helpful for GPS debugging to get the satellite information. The information chosen reflects what is currently available from the PX4 uORB message. I structured the message as per-satellite instead of arrays to allow the CANnode to emit the data on-update and interleaved with the higher rate GNSS sensor messages.

https://github.com/PX4/PX4-Autopilot/blob/main/msg/SatelliteInfo.msg
```
uint64 timestamp		# time since system start (microseconds)
uint8 SAT_INFO_MAX_SATELLITES = 20

uint8 count			# Number of satellites visible to the receiver
uint8[20] svid	 		# Space vehicle ID [1..255], see scheme below
uint8[20] used			# 0: Satellite not used, 1: used for navigation
uint8[20] elevation		# Elevation (0: right on top of receiver, 90: on the horizon) of satellite
uint8[20] azimuth		# Direction of satellite, 0: 0 deg, 255: 360 deg.
uint8[20] snr			# dBHz, Signal to noise ratio of satellite C/N0, range 0..99, zero when not tracking this satellite.
uint8[20] prn                   # Satellite PRN code assignment, (psuedorandom number SBAS, valid codes are 120-144)
```

But I think there are probably other metrics worth considering adding to the message. I'm opening this now to start a discussion.

