### PR TITLE
POWER:BAT: clarified the sign for the current fields

### DIFF
--- a/ardupilot/equipment/power/20004.BatteryInfoAux.uavcan
+++ b/ardupilot/equipment/power/20004.BatteryInfoAux.uavcan
@@ -24,7 +24,7 @@ uint16 cycle_count
 uint16 over_discharge_count
 
 # Max instantaneous current draw since last message
-float16 max_current                 # [Ampere]
+float16 max_current                 # [Ampere] Positive: defined as a discharge current. Negative: defined as a charging current
 
 # Nominal voltage of the battery pack
 # the nominal Voltage can be used for conversion between Wh and Ah

--- a/cuav/equipment/power/20300.CBAT.uavcan
+++ b/cuav/equipment/power/20300.CBAT.uavcan
@@ -2,30 +2,30 @@
 # support for CUAV Smart Battery on UAVCAN
 #
 
-float32 temperature                 # The surface temperature of the battery
-float32 voltage                     # The total voltage of the battery
-float32[<=15] voltage_cell          # Battery individual cell voltages
-uint8 cell_count                    # Number of cells
-float32 current                     # The current flowing through the sense resistor
-float32 average_current             # The average current flowing through the sense resistor
-float32 average_power               # The average power of the current discharge
-float32 available_energy            # The predicted charge or energy remaining in the battery
-float32 remaining_capacity          # The compensated battery capacity remaining
-float32 full_charge_capacity        # The compensated capacity of the battery when fully charged
-float32 design_capacity             # The design capacity of the battery
-uint16 average_time_to_empty        # The predicted remaining battery life at the present rate of discharge, in minutes
-uint16 average_time_to_full         # The predicted remaining time until the battery reaches full charge, in minutes
-uint7 state_of_health               # Health of the battery
-uint7 state_of_charge               # Percent of the full charge [0, 100]
-uint7 max_error                     # max error, expected margin of error in % in the state-of-charge calculation with a range of 1 to 100%
-uint16 serial_number                # serial number of the battery pack
-uint16 manufacture_date             # manufacture date, part of serial number of the battery pack
-uint16 cycle_count                  # number of discharge cycles the battery has experienced
-uint16 over_discharge_count         # Number of battery overdischarge
-float32 passed_charge               # The amount of charge passing through the sense resistor
-float32 nominal_voltage             # Nominal voltage of the battery pack
-bool is_powering_off                # Power off event imminent indication, false if unknown
-uint16 interface_error              # interface error counter
+float32 temperature                 # [Kelvin]      Surface temperature of the battery
+float32 voltage                     # [Volt]        Total voltage of the battery
+float32[<=15] voltage_cell          # [Volt]        Individual cell voltages
+uint8 cell_count                    # [-]           Number of cells
+float32 current                     # [Ampere]      Positive: defined as a discharge current. Negative: defined as a charging current
+float32 average_current             # [Ampere]      Average current. Positive: defined as a discharge current. Negative: defined as a charging current
+float32 average_power               # [Watt]        Average power consumption over the last 10 seconds
+float32 available_energy            # [Joule]       Predicted charge or energy remaining in the battery
+float32 remaining_capacity          # [mAh] Compensated battery remaining capacity
+float32 full_charge_capacity        # [mAh] Compensated capacity of the battery when fully charged
+float32 design_capacity             # [mAh] Design capacity of the battery
+uint16 average_time_to_empty        # [minute]      Predicted remaining battery life at the present rate of discharge
+uint16 average_time_to_full         # [minute]      Predicted remaining time until the battery reaches full charge
+uint7 state_of_health               # [Percent]     Health of the battery
+uint7 state_of_charge               # [Percent]     Percent of the full charge [0, 100]
+uint7 max_error                     # [Percent]     Expected margin of error in the state-of-charge calculation [1, 100]
+uint16 serial_number                # [-]           Serial number of the battery pack
+uint16 manufacture_date             # [-]           Manufacture date, part of serial number of the battery pack
+uint16 cycle_count                  # [-]           Number of discharge cycles the battery has experienced
+uint16 over_discharge_count         # [-]           Number of battery overdischarge events
+float32 passed_charge               # [Coulomb]     Amount of charge that has passed through the sense resistor
+float32 nominal_voltage             # [Volt]        Nominal voltage of the battery pack
+bool is_powering_off                # [-]           Power off event imminent indication, false if unknown
+uint16 interface_error              # [-]           Interface error counter
 
 uint11 STATUS_FLAG_IN_USE       = 1     # The battery is currently used as a power supply
 uint11 STATUS_FLAG_CHARGING     = 2     # Charger is active

--- a/uavcan/equipment/power/1092.BatteryInfo.uavcan
+++ b/uavcan/equipment/power/1092.BatteryInfo.uavcan
@@ -14,7 +14,7 @@
 #
 float16 temperature             # [Kelvin]
 float16 voltage                 # [Volt]
-float16 current                 # [Ampere]
+float16 current                 # [Ampere]      Positive: defined as a discharge current. Negative: defined as a charging current
 float16 average_power_10sec     # [Watt]        Average power consumption over the last 10 seconds
 float16 remaining_capacity_wh   # [Watt hours]  Will be increasing during charging
 float16 full_charge_capacity_wh # [Watt hours]  Predicted battery capacity when it is fully charged. Falls with aging


### PR DESCRIPTION
## Issue:
From the Message definition of BatteryInfo and BatteryInfoAux it it not clear if a discharge current should be positive or negative, which has lead different manufacturers to implement it differently, (E.g CUAV CAN power module, reports positive current for discharging, and TATTU Smart Battery reports negative current for discharging)
The same issue for the CUAV CBAT message, no units were present for any of the fields.

## Solution:
- Added note at the end which aligns it with other [dronecan messages ](https://github.com/dronecan/DSDL/blob/master/ardupilot/equipment/power/20010.BatteryContinuous.uavcan)
- Added units to the CUAV message