### PR TITLE
1092 Battery Info: STATE_OF_CHARGE_UNKNOWN constant definition

### DIFF
--- a/uavcan/equipment/power/1092.BatteryInfo.uavcan
+++ b/uavcan/equipment/power/1092.BatteryInfo.uavcan
@@ -50,6 +50,7 @@ uint7 state_of_health_pct               # Health of the battery, in percent, opt
 # Relative State of Charge (SOC) estimate, in percent.
 # http://en.wikipedia.org/wiki/State_of_charge
 #
+uint7 STATE_OF_CHARGE_UNKNOWN = 127     # Use this constant if SoC cannot be estimated
 uint7 state_of_charge_pct               # Percent of the full charge [0, 100]. This field is required
 uint7 state_of_charge_pct_stdev         # SOC error standard deviation; use best guess if unknown
 


### PR DESCRIPTION
SOC should not be zero when not able to estimate it.