### PR TITLE
gnss.quality

### DIFF
--- a/uavcan/equipment/gnss/1064.Quality.uavcan
+++ b/uavcan/equipment/gnss/1064.Quality.uavcan
@@ -1,0 +1,109 @@
+#
+# GNSS signal quality and integrity metrics.
+#
+# Supplementary message providing signal quality, interference detection,
+# and correction status not carried by Fix2 or Auxiliary.
+# Publish alongside Fix2 at the same or lower rate.
+#
+# Supports: u-blox (MON-RF, NAV-PVT, NAV-STATUS, SEC-SIG),
+#           Septentrio, and other receivers with quality reporting.
+#
+
+#
+# Noise level as measured by the GNSS receiver.
+# Receiver-specific units. u-blox: noisePerMS from UBX-MON-RF.
+# -1 if unavailable.
+#
+int16 noise
+
+#
+# Automatic gain control monitor.
+# u-blox: agcCnt from UBX-MON-RF (0-8191, percentage of max gain).
+# 0xFFFF if unavailable.
+#
+uint16 agc
+
+#
+# Jamming/interference state (aligns with MAVLink GPS_JAMMING_STATE).
+#
+uint8 JAMMING_UNKNOWN    = 0
+uint8 JAMMING_OK         = 1     # No significant jamming
+uint8 JAMMING_WARNING    = 2     # Interference visible, fix OK
+uint8 JAMMING_CRITICAL   = 3     # Interference visible, fix degraded/lost
+uint8 jamming_state
+
+#
+# Jamming indicator [0-255]. Higher = more interference.
+# u-blox: jamInd from UBX-MON-RF or cwSuppression.
+#
+uint8 jamming_indicator
+
+#
+# Spoofing detection state (aligns with MAVLink GPS_SPOOFING_STATE).
+#
+uint8 SPOOFING_UNKNOWN   = 0
+uint8 SPOOFING_OK        = 1
+uint8 SPOOFING_WARNING   = 2     # Possible spoofing, mitigated
+uint8 SPOOFING_INDICATED = 3
+uint8 spoofing_state
+
+#
+# Signal authentication state (Galileo OSNMA, GPS CHIMERA, etc.)
+# Aligns with MAVLink GPS_AUTHENTICATION_STATE.
+#
+uint8 AUTH_UNKNOWN       = 0
+uint8 AUTH_INITIALIZING  = 1
+uint8 AUTH_ERROR         = 2
+uint8 AUTH_OK            = 3
+uint8 AUTH_DISABLED      = 4
+uint8 auth_state
+
+#
+# Differential correction age [seconds].
+# Time since last valid correction was applied.
+# 0 = corrections just received.
+# 0xFFFF = unavailable or not applicable.
+# u-blox: derived from UBX-NAV-PVT flags3.lastCorrectionAge
+# (convert binned value to representative seconds).
+#
+uint16 diff_age
+
+#
+# Antenna supervisor state.
+#
+uint8 ANTENNA_STATUS_UNKNOWN = 0
+uint8 ANTENNA_STATUS_INIT    = 1
+uint8 ANTENNA_STATUS_OK      = 2
+uint8 ANTENNA_STATUS_SHORT   = 3
+uint8 ANTENNA_STATUS_OPEN    = 4
+uint8 antenna_status
+
+#
+# Antenna power status.
+#
+uint8 ANTENNA_POWER_UNKNOWN  = 0
+uint8 ANTENNA_POWER_OFF      = 1
+uint8 ANTENNA_POWER_ON       = 2
+uint8 antenna_power
+
+#
+# Fix quality/confidence indicator [0-100].
+# Receiver's assessment of fix quality, independent of fix_type.
+# 0 = no confidence / invalid, 100 = full confidence.
+# Receivers without internal quality metrics can derive from fix_type:
+#   NO_FIX=0, 2D=30, 3D=60, DGPS=75, RTK_FLOAT=85, RTK_FIXED=100
+#
+uint8 fix_quality
+
+#
+# System error flags (bitmask).
+# Aligns with PX4 SensorGps.msg SYSTEM_ERROR_* flags.
+#
+uint16 SYSTEM_ERROR_INCOMING_CORRECTIONS = 1
+uint16 SYSTEM_ERROR_CONFIGURATION        = 2
+uint16 SYSTEM_ERROR_SOFTWARE             = 4
+uint16 SYSTEM_ERROR_ANTENNA              = 8
+uint16 SYSTEM_ERROR_EVENT_CONGESTION     = 16
+uint16 SYSTEM_ERROR_CPU_OVERLOAD         = 32
+uint16 SYSTEM_ERROR_OUTPUT_CONGESTION    = 64
+uint16 system_errors

--- a/uavcan/equipment/gnss/1064.Quality.uavcan
+++ b/uavcan/equipment/gnss/1064.Quality.uavcan
@@ -87,13 +87,15 @@ uint8 ANTENNA_POWER_ON       = 2
 uint8 antenna_power
 
 #
-# Fix quality/confidence indicator [0-100].
-# Receiver's assessment of fix quality, independent of fix_type.
-# 0 = no confidence / invalid, 100 = full confidence.
-# Receivers without internal quality metrics can derive from fix_type:
-#   NO_FIX=0, 2D=30, 3D=60, DGPS=75, RTK_FLOAT=85, RTK_FIXED=100
+# Abstract quality indicators [0-10], 255 if unavailable.
+# Aligned with MAVLink GNSS_INTEGRITY (id 441).
+# Higher values indicate higher quality. Semantics follow the receiver's
+# own definition (e.g. Septentrio QualityInd SBF block).
 #
-uint8 fix_quality
+uint8 corrections_quality        # Quality of incoming differential corrections
+uint8 system_status_summary      # Overall receiver operating status
+uint8 gnss_signal_quality        # Quality of received GNSS signals
+uint8 post_processing_quality    # Expected post-processing quality
 
 #
 # System error flags (bitmask).


### PR DESCRIPTION
## Summary

Adds `uavcan.equipment.gnss.Quality` (id 1064) — a supplementary GNSS message covering signal integrity, interference detection, correction status, and antenna supervision that doesn't fit `Fix2` or `Auxiliary`.

## Why

`Fix2` and `Auxiliary` carry position, velocity, and DOP but leave several fields that modern receivers (u-blox, Septentrio, …) expose unaccounted for in DroneCAN:

- Noise / AGC / jamming / spoofing / signal authentication state
- Differential correction age
- Antenna supervisor state (short / open / power)
- Abstract receiver quality indicators
- System-level error flags

These map directly onto fields already defined by MAVLink `GNSS_INTEGRITY` (id 441) and PX4's `sensor_gps` / `sensor_gnss_status` topics, so a DroneCAN GNSS node can now carry the same integrity information as its serial/MAVLink counterparts.

## Field groups

| Group | Fields |
|---|---|
| Noise / AGC | `noise`, `agc` |
| Interference | `jamming_state`, `jamming_indicator`, `spoofing_state`, `auth_state` |
| Corrections | `diff_age` |
| Antenna | `antenna_status`, `antenna_power` |
| Quality (0-10, 255 = N/A) | `corrections_quality`, `system_status_summary`, `gnss_signal_quality`, `post_processing_quality` |
| System errors (bitmask, u16) | `system_errors` |

Quality fields mirror MAVLink `GNSS_INTEGRITY` semantics (0-10 scale, same meaning). Receivers without an abstract quality metric should leave them at 255 rather than synthesize one.

## Transport

- Payload: **18 B** → 3 DroneCAN frames (5 + 7 + 6 B)
- @ 10 Hz on a 1 Mbps bus: ~0.4 % bus load
- @ 10 Hz on a 500 kbps bus: < 1 %

Intended to be published alongside `Fix2` at the same or lower rate.

## Related

- PX4-Autopilot bridge & uavcannode publisher: PX4/PX4-Autopilot#26438
- u-blox driver fields (MON-RF, NAV-PVT flags3): PX4/PX4-GPSDrivers#200
