### PR TITLE
added ChannelConfig message for configuration of multi-actuator setups

### DIFF
--- a/uavcan/equipment/actuator/1012.ChannelConfig.uavcan
+++ b/uavcan/equipment/actuator/1012.ChannelConfig.uavcan
@@ -1,0 +1,30 @@
+#
+# Actuator channel config.
+#
+# Entry at index i configures the handling of ArrayCommand commands where
+# Command.actuator_id == i.
+#
+# A receiver whose own actuator_id matches mapped_actuator_id[i] shall route
+# that command to its local output channel actuator_channel[i].
+#
+# mapped_actuator_id is a user-assigned node identifier, independent of the CAN node ID
+# (e.g. set via DIP switch). Valid range: 0..254. NOT_CONFIGURED (255) marks unused entries.
+#
+# Local outputs not covered by any matching entry shall be treated as uncontrolled.
+#
+# Duplicate entries with the same mapped_actuator_id and actuator_channel are a
+# configuration error. The behavior is undefined.
+#
+# The sender shall publish this message periodically at low rate and is responsible for retaining the
+# configuration persistently. Receivers do not need to persist the mapping to non-volatile storage.
+#
+# Receivers configured to use this message shall not process ArrayCommand
+# until at least one ChannelConfig has been received.
+#
+# Nodes not configured to use this message shall process all commands according to their rules.
+#
+
+uint8 NOT_CONFIGURED = 255
+
+uint8[<=30] mapped_actuator_id
+uint8[<=30] actuator_channel


### PR DESCRIPTION
**Context**

This started off as a specific feature needed by our company but I think others could also benefit from it.

The current `ArrayCommand` setup works great for simple setups or in case one can assign individual actuator IDs to each servo. It already gets harder to use when one has a general CAN to PWM board with multiple output channels in which case a mapping on each node is needed.

In bigger setups that are produced at scale all of this does not scale well as changing the setup requires connecting to individual servos or individual CAN to PWM boards. To deploy such setups it is easier to set up all nodes once and only change the configuration on the flight controller.

**Solution**

A new message `ChannelConfig` is introduced which originates from the flight controller and is received by servos / CAN to PWM boards. In it, the flight controller can specify which actuator (using its ID) should handle a Command on which of its channels. All of it is 0-based. For example when ArrayCommand contains two commands, it could specify that actuator 0 should handle Command 0 on its channel 0 and actuator 1 should handle Command 1 on its channel 3.

This scales well to more complex setups where one has CAN to PWM boards in each wing and tail of a larger fixed-wing. After assigning actuator IDs to each of the nodes, one can dynamically change which node handles what on which channel.

**Compatibility**

This message is optional. If the flight controller does not send it or an actuator does not react to it, the current behavior stays unchanged. The idea is that the nodes have a parameter that controls whether they react to this message and only process it when enabled. When enabled, they have to wait for one `ChannelConfig` before processing `ArrayCommand`. The frequency of `ChannelConfig` can be very low as it should not change frequently (or at all) after startup.