### PR TITLE
Add Ion ModuleStatus vendor message

### DIFF
--- a/ion/20540.ModuleStatus.uavcan
+++ b/ion/20540.ModuleStatus.uavcan
@@ -1,0 +1,18 @@
+#
+# Ion Module State
+#
+# Reports application-specific operational state for an Ion module.
+#
+# This message complements uavcan.protocol.NodeStatus.
+# Generic node health and operating mode shall be reported using
+# uavcan.protocol.NodeStatus.
+#
+
+uint8 MODULE_OFF  = 0
+uint8 MODULE_ON  = 1
+uint8 MODULE_TIMER_COMPLETE = 2
+uint8 MODULE_READY = 3
+
+float16 supply_voltage
+uint8 module_state
+uint32 timer_elapsed_ms


### PR DESCRIPTION
## Summary

This pull request adds the following Ion Controls vendor-specific DroneCAN data type:

- `20540 ion.ModuleStatus`

The message reports the module supply voltage, operating state, and elapsed timer value.

## Vendor message-ID request

Ion Controls Ltd would also like to request the following vendor-specific message-ID allocation:

- `20540–20549`, inclusive

ID `20540` is assigned by this pull request to `ion.ModuleStatus`.

IDs `20541–20549` are requested for future Ion Controls vendor-specific DroneCAN messages. No placeholder DSDL definitions have been created for these unused IDs.

Please could the maintainers confirm whether the complete `20540–20549` block can be recognised as reserved for Ion Controls Ltd.

Thank you.

## Testing

The `ion.ModuleStatus` definition has been successfully compiled using `dronecan_dsdlc` and is in use on an STM32H7 DroneCAN node.