### PR TITLE
add dronecan 345.CanConfig message

### DIFF
--- a/dronecan/protocol/345.CanConfig.uavcan
+++ b/dronecan/protocol/345.CanConfig.uavcan
@@ -1,0 +1,18 @@
+#
+# Provide information on the CAN bus configuration
+#
+
+# Common CAN bitrates
+uint32 CAN_BITRATE_1MBPS = 1000000
+uint32 CAN_BITRATE_2MBPS = 2000000
+uint32 CAN_BITRATE_4MBPS = 4000000
+uint32 CAN_BITRATE_5MBPS = 5000000
+uint32 CAN_BITRATE_8MBPS = 8000000
+
+# CAN variants
+uint3 CAN_CLASSIC = 0
+uint3 CAN_FD = 1
+
+uint32 bit_rate         # bit rate
+uint3  variant          # 0: classsic CAN, 1: CAN FD, 2-7: for future variants like XL
+uint5  reserved


### PR DESCRIPTION
adds the broadcast message 345.CanConfig, for reporting CAN bus configuration information such as bitrate or CAN variant.

problem it solves:
mLRS is supporting DroneCan since a longer while, and commerically available hardware has also become available some time ago. We now want to also support CAN FD, but possibly in a user friendly way. While what we have is working perfectly fine, and it is easy enough code-wise to autodetect and switch from classic CAN to CAN FD, autodetecting the bitrate is pretty clumsy and we would like to avoid such code.
The proposed CanConfig message is reporting such info to interested nodes, and the idea is that it is send by ArduPilot alongside the dynamic_node_id.Allocation message, when the dynamic node id allocation is finished.

That is, codewise, all change needed in ArduPilot is to add after that line here https://github.com/ArduPilot/ardupilot/blob/master/libraries/AP_DroneCAN/AP_DroneCAN_DNA_Server.cpp#L559 a line which publishes the CanConfig message.

From the user side, all they have to do is to configure ArduPilot, which they have to do anyway, but it would avoid specifc configuration on the node side. We believe users would welcome this simplification.

Alternatives:
The message could be designed as a service, such that nodes can actively request this info. However, the disadvantage in our opinion is that nodes then do have to actively request for it. This would add additional code on both the node and ArduPilot side, with no benefit in our opinion.

A further approach would be the capabilities service considered in https://github.com/dronecan/DSDL/pull/4. This approach is however way more sophisticated. It would e.g. require nodes to constantly watch out for possible can bus reconfigurations, and it's questionable if nodes should have control over the bitrate. Moreover, the proposed mechanism can perfectly coexist with a capabilities approach, if that should ever be installed.

Extensions:
The message could possible extended by further info, for instance, can bus timing info.
